### PR TITLE
Fixes #27 - Use six.iteritems for python3 compat

### DIFF
--- a/ooxml/serialize.py
+++ b/ooxml/serialize.py
@@ -989,7 +989,7 @@ class HeaderContext:
                 except:
                     pass
 
-            sorted_list_of_sizes = list(collections.OrderedDict(sorted(list_of_sizes.iteritems(), key=lambda t: t[0])))
+            sorted_list_of_sizes = list(collections.OrderedDict(sorted(six.iteritems(list_of_sizes), key=lambda t: t[0])))
             font_size_to_check = font_size
 
             if len(sorted_list_of_sizes) > 0:


### PR DESCRIPTION
Since I see six is already in use here, looks like this was just an omission.